### PR TITLE
make column names lowercase in GCS utils

### DIFF
--- a/src/mozilla_sec_eia/utils/cloud.py
+++ b/src/mozilla_sec_eia/utils/cloud.py
@@ -229,8 +229,8 @@ class GCSArchive(BaseModel):
     ) -> Path:
         """Return path to a filing in local cache based on metadata."""
         return cache_directory / Path(
-            f"{filing['CIK']}-{filing['year_quarter']}-"
-            f"{filing['Filename'].replace('edgar/data/', '').replace('/', '-')}".replace(
+            f"{filing['cik']}-{filing['year_quarter']}-"
+            f"{filing['filename'].replace('edgar/data/', '').replace('/', '-')}".replace(
                 ".txt", extension
             )
         )
@@ -272,13 +272,13 @@ class GCSArchive(BaseModel):
         """
         filings = []
         for _, filing in filing_selection.iterrows():
-            blob = self.get_filing_blob(filing["year_quarter"], filing["Filename"])
+            blob = self.get_filing_blob(filing["year_quarter"], filing["filename"])
             local_path = self._get_local_path(cache_directory, filing)
             filing_path = self.cache_blob(blob, local_path)
             filings.append(
                 Sec10K.from_path(
                     filing_path,
-                    filing["CIK"],
+                    filing["cik"],
                     filing["year_quarter"],
                     filing["exhibit_21_version"],
                 )
@@ -311,7 +311,7 @@ class GCSArchive(BaseModel):
             # Cache filing
             match = label_name_pattern.search(blob.name)
             filename = f"edgar/data/{match.group(1)}/{match.group(2)}.txt"
-            filing_metadata = metadata_df[metadata_df["Filename"] == filename]
+            filing_metadata = metadata_df[metadata_df["filename"] == filename]
             filing = self.get_filings(filing_metadata)[0]
             pdf_path = self._get_local_path(
                 pdf_cache_path, filing_metadata.iloc[0], extension=".pdf"
@@ -331,7 +331,7 @@ class GCSArchive(BaseModel):
 
         # Get metadata df
         logger.info("Get list of files in metadata.")
-        metadata_filenames = set(self.get_metadata()["Filename"])
+        metadata_filenames = set(self.get_metadata()["filename"])
 
         if not (valid := archive_filenames == metadata_filenames):
             logger.warning("Archive validation failed.")

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -89,7 +89,7 @@ def test_validate_archive(test_archive, archive_files, metadata_files, valid, mo
     test_archive._filings_bucket.list_blobs.return_value = archive_files
 
     metadata_mock = mocker.MagicMock(
-        return_value=pd.DataFrame({"Filename": metadata_files})
+        return_value=pd.DataFrame({"filename": metadata_files})
     )
     mocker.patch(
         "mozilla_sec_eia.utils.cloud.GCSArchive.get_metadata", new=metadata_mock


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

Tiny fix to make the GCS archiver utils work. At some point I think the column names of the metadata become lowercase and this wasn't reflected in this cloud utils module.
