### PR TITLE
Tox Fix

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
       fail-fast: false
     defaults:
       run:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run PyTest with Tox
         run: |
-          tox
+          conda run -n mozilla-sec-eia tox
 
       - name: Upload test coverage report to CodeCov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run PyTest with Tox
         run: |
-          conda run -n mozilla-sec-eia tox
+          tox
 
       - name: Upload test coverage report to CodeCov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 dependencies = [
     "accelerate>=0.21.0,<2.0", # Hugging Face dependency for PyTorch models
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
     "cloud-sql-python-connector[pg8000]",
     "dagster>=1.7.15", # 1.7.13 & 1.7.14 were both breaking things
     "dagster-mlflow",

--- a/test_environment.yml
+++ b/test_environment.yml
@@ -29,6 +29,10 @@ dependencies:
   - pytorch>=2.2,<3
   - torchvision
 
+  # GDAL is a transitive dependency whose binaries must match those installed by the
+  # pudl-dev conda environment, so we also install it with conda here.
+  - gdal==3.9.3 # pinned to ensure it matches pudl-dev environment exactly.
+
   # Use pip to install the package defined by this repo for development:
   - pip:
       - --editable ./[dev,docs,tests,types]


### PR DESCRIPTION

OK, so it looks like it can't find `pudl` when importing:

```
ImportError while importing test module '/home/runner/work/mozilla-sec-eia/mozilla-sec-eia/.env_tox/lib/python3.12/site-packages/mozilla_sec_eia/library/record_linkage_utils.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../micromamba/envs/mozilla-sec-eia/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
.env_tox/lib/python3.12/site-packages/mozilla_sec_eia/library/record_linkage_utils.py:6: in <module>
    from pudl.analysis.record_linkage import name_cleaner
E   ModuleNotFoundError: No module named 'pudl'
```

So I looked at how we set up the environment in `tox-pytest.yml` - which seems to set up a conda environment using `test_environment.yml`. That installs `.` into a conda env called `mozilla-sec-eia` but doesn't install `pudl`. I'm not sure what version of `pudl` we need to pin to, but in `pudl-archiver` we pin to main so I just copied that over.

That means we need to set up `tox-pytest` to only run on Python 3.12, since that's what's required of `pudl`.

Finally we also need to install `gdal==3.9.3` in the `mozilla-sec-eia` conda env because we use `gdal==3.9.3` in PUDL.

If all you're doing is using PUDL for the name cleaning it might make sense to just copy-paste the code and avoid this dependency :shrug:

Even after this, the CI still fails, but due to a segfault in the testing, not due to tox not being able to find PUDL.

However, I wouldn't rule out the possibility that the segfault is due to some weird thing that we've pulled in due to the PUDL dependency... haven't looked too deep into it.